### PR TITLE
VG-1878: Fixed validating and ignoring invalid phone numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `digipolisgent/toerismevlaanderen-lodging` package.
 
+## [Unreleased]
+
+### Fixed
+
+* VG-1878: Fixed validating and ignoring invalid phone numbers.
+
 ## [0.2.2]
 
 ### Fixed

--- a/src/Normalizer/FromJson/ContactInfoNormalizer.php
+++ b/src/Normalizer/FromJson/ContactInfoNormalizer.php
@@ -11,6 +11,7 @@ use DigipolisGent\Toerismevlaanderen\Lodging\Value\PhoneNumber;
 use DigipolisGent\Toerismevlaanderen\Lodging\Value\PhoneNumbers;
 use DigipolisGent\Toerismevlaanderen\Lodging\Value\WebsiteAddress;
 use DigipolisGent\Toerismevlaanderen\Lodging\Value\WebsiteAddresses;
+use InvalidArgumentException;
 
 /**
  * Normalizer to get the contact info out of json decoded data.
@@ -56,7 +57,11 @@ class ContactInfoNormalizer
         $numbers = $this->extractValuesFromString($data);
         $phoneNumbers = [];
         foreach ($numbers as $number) {
-            $phoneNumbers[] = PhoneNumber::fromNumber($number);
+            try {
+                $phoneNumbers[] = PhoneNumber::fromNumber($number);
+            } catch (InvalidArgumentException $exception) {
+                continue;
+            }
         }
         $phoneNumbers = array_reverse($phoneNumbers);
 

--- a/src/Value/PhoneNumber.php
+++ b/src/Value/PhoneNumber.php
@@ -6,6 +6,7 @@ namespace DigipolisGent\Toerismevlaanderen\Lodging\Value;
 
 use DigipolisGent\Value\ValueAbstract;
 use DigipolisGent\Value\ValueInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * PhoneNumber value.
@@ -35,6 +36,8 @@ final class PhoneNumber extends ValueAbstract
      */
     public static function fromNumber(string $number): PhoneNumber
     {
+        Assert::startsWith($number, '+');
+
         $phoneNumber = new static();
         $phoneNumber->number = $number;
 

--- a/tests/Normalizer/FromJson/ContactInfoNormalizerTest.php
+++ b/tests/Normalizer/FromJson/ContactInfoNormalizerTest.php
@@ -30,7 +30,7 @@ class ContactInfoNormalizerTest extends TestCase
     "bindings": [
       {
         "contactPoint_phoneNumbers": {
-          "value": "+32 9 123 00 02,+32 9 123 00 01",
+          "value": "+32 9 123 00 02,+32 9 123 00 01,123",
           "type": "literal"
         },
         "contactPoint_emailAddresses": {
@@ -54,6 +54,7 @@ EOT;
      */
     public function allLodgingDataIsNormalized(): void
     {
+        // Invalid phone numbers are ignored.
         $expectedPhoneNumbers = PhoneNumbers::fromPhoneNumbers(
             PhoneNumber::fromNumber('+32 9 123 00 01'),
             PhoneNumber::fromNumber('+32 9 123 00 02')

--- a/tests/Value/PhoneNumberTest.php
+++ b/tests/Value/PhoneNumberTest.php
@@ -24,6 +24,17 @@ class PhoneNumberTest extends TestCase
     }
 
     /**
+     * Exception if number does not start with an "+".
+     *
+     * @test
+     */
+    public function exceptionIsThrownWhenPhoneNumberDoesNotStartWithPlus(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        PhoneNumber::fromNumber('123');
+    }
+
+    /**
      * Not the same value if numbers are different.
      *
      * @test


### PR DESCRIPTION
All phone numbers should be prefixed by a `+`. Sometimes faulty data is
returned by the Lodging service.

Added:

* Validating the phone number value when creating PhoneNumber value.
* Ignoring faulty phone numbers while normalizing the json data into a
  ContactInfo value.