### PR TITLE
VG-1878: Reverted validating and ignoring phone numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `digipolisgent/toerismevlaanderen-lodging` package.
 
+## [Unreleased]
+
+### Fixed
+
+* VG-1878: Reverted validating and ignoring phone numbers.
+
 ## [0.2.3]
 
 ### Fixed

--- a/src/Normalizer/FromJson/ContactInfoNormalizer.php
+++ b/src/Normalizer/FromJson/ContactInfoNormalizer.php
@@ -11,7 +11,6 @@ use DigipolisGent\Toerismevlaanderen\Lodging\Value\PhoneNumber;
 use DigipolisGent\Toerismevlaanderen\Lodging\Value\PhoneNumbers;
 use DigipolisGent\Toerismevlaanderen\Lodging\Value\WebsiteAddress;
 use DigipolisGent\Toerismevlaanderen\Lodging\Value\WebsiteAddresses;
-use InvalidArgumentException;
 
 /**
  * Normalizer to get the contact info out of json decoded data.
@@ -57,11 +56,7 @@ class ContactInfoNormalizer
         $numbers = $this->extractValuesFromString($data);
         $phoneNumbers = [];
         foreach ($numbers as $number) {
-            try {
-                $phoneNumbers[] = PhoneNumber::fromNumber($number);
-            } catch (InvalidArgumentException $exception) {
-                continue;
-            }
+            $phoneNumbers[] = PhoneNumber::fromNumber($number);
         }
         $phoneNumbers = array_reverse($phoneNumbers);
 

--- a/src/Value/PhoneNumber.php
+++ b/src/Value/PhoneNumber.php
@@ -6,7 +6,6 @@ namespace DigipolisGent\Toerismevlaanderen\Lodging\Value;
 
 use DigipolisGent\Value\ValueAbstract;
 use DigipolisGent\Value\ValueInterface;
-use Webmozart\Assert\Assert;
 
 /**
  * PhoneNumber value.
@@ -36,8 +35,6 @@ final class PhoneNumber extends ValueAbstract
      */
     public static function fromNumber(string $number): PhoneNumber
     {
-        Assert::startsWith($number, '+');
-
         $phoneNumber = new static();
         $phoneNumber->number = $number;
 

--- a/tests/Normalizer/FromArray/ContactInfoNormalizerTest.php
+++ b/tests/Normalizer/FromArray/ContactInfoNormalizerTest.php
@@ -47,6 +47,7 @@ class ContactInfoNormalizerTest extends TestCase
     public function allContactPointDataIsNormalized(): void
     {
         $data = [
+            // Invalid phone numbers are ignored.
             'phoneNumbers' => ['+32 9 123 12 12'],
             'emailAddresses' => ['foo@biz.baz'],
             'websiteAddresses' => ['https://foo.baz'],

--- a/tests/Normalizer/FromJson/ContactInfoNormalizerTest.php
+++ b/tests/Normalizer/FromJson/ContactInfoNormalizerTest.php
@@ -30,7 +30,7 @@ class ContactInfoNormalizerTest extends TestCase
     "bindings": [
       {
         "contactPoint_phoneNumbers": {
-          "value": "+32 9 123 00 02,+32 9 123 00 01,123",
+          "value": "+32 9 123 00 02,+32 9 123 00 01",
           "type": "literal"
         },
         "contactPoint_emailAddresses": {

--- a/tests/Value/PhoneNumberTest.php
+++ b/tests/Value/PhoneNumberTest.php
@@ -24,17 +24,6 @@ class PhoneNumberTest extends TestCase
     }
 
     /**
-     * Exception if number does not start with an "+".
-     *
-     * @test
-     */
-    public function exceptionIsThrownWhenPhoneNumberDoesNotStartWithPlus(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        PhoneNumber::fromNumber('123');
-    }
-
-    /**
      * Not the same value if numbers are different.
      *
      * @test


### PR DESCRIPTION
The data quality of the phone numbers in the lodging data set is not
guaranteed. To validating is removed so invalid data can be consulted.